### PR TITLE
Allow for round-robin rotation of assignees

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
     # Repo code checkout required if `template` is used
     - name: Checkout
       uses: actions/checkout@v2
-      
+
     - name: issue-bot
       uses: imjohnbo/issue-bot@v2
       with:
@@ -67,7 +67,7 @@ jobs:
         labels: "tps, bug"
         pinned: false
         close-previous: false
-        template: "tps.md" 
+        template: "tps.md"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -116,6 +116,7 @@ jobs:
 - `labels`: Comma delimited list of issue labels. Required value either as input or in YAML header of issue template.
 - `title`: Issue title. Required value either as input or in YAML header of issue template.
 - `assignees`: Comma delimited list of issue assignees.
+- `rotate-assignees`: 
 - `body`: Issue body.
 - `pinned`: Whether to [pins the issue](https://help.github.com/en/github/managing-your-work-on-github/pinning-an-issue-to-your-repository) and unpin the previous one.
 - `close-previous`: Whether to close the most recent previous issue with a matching label.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ jobs:
 - `labels`: Comma delimited list of issue labels. Required value either as input or in YAML header of issue template.
 - `title`: Issue title. Required value either as input or in YAML header of issue template.
 - `assignees`: Comma delimited list of issue assignees.
-- `rotate-assignees`: 
+- `rotate-assignees`: Whether to round robin the provided assignees (i.e. for first responder duties)
 - `body`: Issue body.
 - `pinned`: Whether to [pins the issue](https://help.github.com/en/github/managing-your-work-on-github/pinning-an-issue-to-your-repository) and unpin the previous one.
 - `close-previous`: Whether to close the most recent previous issue with a matching label.

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Comma delimited list of issue assignees'
     default: ''
     required: false
+  rotate-assignees:
+    description: 'Whether to round robin the provided assisgness (i.e. for first responder duties)'
+    default: 'false'
+    required: false
   body:
     description: 'Issue body'
     default: ''

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: ''
     required: false
   rotate-assignees:
-    description: 'Whether to round robin the provided assisgness (i.e. for first responder duties)'
+    description: 'Whether to round robin the provided assignees (i.e. for first responder duties)'
     default: 'false'
     required: false
   body:

--- a/dist/index.js
+++ b/dist/index.js
@@ -204,7 +204,7 @@ async function run () {
     const previousIssueNumber = latestIssueQuery.number
     const previousId = latestIssueQuery.id
     let currentAssignee = ''
-    if (latestIssueQuery.assignees.nodes.length() > 0) {
+    if (latestIssueQuery.assignees.nodes && latestIssueQuery.assignees.nodes.length() > 0) {
       currentAssignee = latestIssueQuery.assignees.nodes[0].login
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -232,6 +232,8 @@ async function run () {
       metadata.assignees = [`'${metadata.assignees[index]}'`]
     }
 
+    core.debug(`Metadata.assignees: ${metadata.assignees}`)
+
     // Create a new issue
     const { data: { number: newIssueNumber } } = await octokit.issues.create({
       ...github.context.repo,

--- a/dist/index.js
+++ b/dist/index.js
@@ -202,8 +202,6 @@ async function run () {
     // Run the query, save the number (ex. 79) and GraphQL id (ex. MDU6SXMzbWU0ODAxNzI0NDA=)
     const latestIssueResponse = (await octokit.graphql(latestIssueQuery)).resource.issues.nodes[0] || {};
 
-    core.debug(`Latest issue response:\n\n${JSON.stringify(latestIssueResponse)}\n\n`)
-
     const previousIssueNumber = latestIssueResponse.number
     const previousIssueId = latestIssueResponse.id
     let currentAssignee = null

--- a/dist/index.js
+++ b/dist/index.js
@@ -203,7 +203,10 @@ async function run () {
     const latestIssueResponse = (await octokit.graphql(latestIssueQuery)).resource.issues.nodes[0] || {};
     const previousIssueNumber = latestIssueQuery.number
     const previousId = latestIssueQuery.id
-    const currentAssignee = latestIssueQuery.assignees.nodes[0].login
+    let currentAssignee = ''
+    if (latestIssueQuery.assignees.nodes.length() > 0) {
+      currentAssignee = latestIssueQuery.assignees.nodes[0].login
+    }
 
     core.debug(`Previous issue number: ${previousIssueNumber}`);
     core.debug(`Previous issue currentAssignee: ${currentAssignee}`);
@@ -212,7 +215,7 @@ async function run () {
     body = Handlebars.compile(body)({ previousIssueNumber });
 
     // Rotate assignee to next in list?
-    if (rotateAssignees) {
+    if (rotateAssignees && currentAssignee !== '') {
       let index = metadata.assignees.indexOf();
       const length = metadata.assignees.length();
       // If last assignee in array

--- a/dist/index.js
+++ b/dist/index.js
@@ -207,7 +207,7 @@ async function run () {
     const previousIssueNumber = latestIssueResponse.number
     const previousId = latestIssueResponse.id
     let currentAssignee = null
-    if (latestIssueResponse.assignees && latestIssueResponse.assignees.nodes.length() > 0) {
+    if (latestIssueResponse.assignees && latestIssueResponse.assignees.nodes.length > 0) {
       currentAssignee = latestIssueResponse.assignees.nodes[0].login
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -206,8 +206,8 @@ async function run () {
 
     const previousIssueNumber = latestIssueResponse.number
     const previousId = latestIssueResponse.id
-    let currentAssignee = ''
-    if (latestIssueResponse.assignees.nodes && latestIssueResponse.assignees.nodes.length() > 0) {
+    let currentAssignee = null
+    if (latestIssueResponse.assignees && latestIssueResponse.assignees.nodes.length() > 0) {
       currentAssignee = latestIssueResponse.assignees.nodes[0].login
     }
 
@@ -218,8 +218,8 @@ async function run () {
     body = Handlebars.compile(body)({ previousIssueNumber });
 
     // Rotate assignee to next in list?
-    if (rotateAssignees && currentAssignee !== '') {
-      let index = metadata.assignees.indexOf();
+    if (rotateAssignees) {
+      let index = metadata.assignees.indexOf(currentAssignee);
       const length = metadata.assignees.length();
       // If last assignee in array
       if (length - 1 <= index) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -220,7 +220,7 @@ async function run () {
     // Rotate assignee to next in list?
     if (rotateAssignees) {
       let index = metadata.assignees.indexOf(currentAssignee);
-      const length = metadata.assignees.length();
+      const length = metadata.assignees.length;
       // If last assignee in array
       if (length - 1 <= index) {
         index = 0;

--- a/dist/index.js
+++ b/dist/index.js
@@ -204,11 +204,11 @@ async function run () {
 
     core.debug(`Latest issue response:\n\n${JSON.stringify(latestIssueResponse)}\n\n`)
 
-    const previousIssueNumber = latestIssueQuery.number
-    const previousId = latestIssueQuery.id
+    const previousIssueNumber = latestIssueResponse.number
+    const previousId = latestIssueResponse.id
     let currentAssignee = ''
-    if (latestIssueQuery.assignees.nodes && latestIssueQuery.assignees.nodes.length() > 0) {
-      currentAssignee = latestIssueQuery.assignees.nodes[0].login
+    if (latestIssueResponse.assignees.nodes && latestIssueResponse.assignees.nodes.length() > 0) {
+      currentAssignee = latestIssueResponse.assignees.nodes[0].login
     }
 
     core.debug(`Previous issue number: ${previousIssueNumber}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -205,7 +205,7 @@ async function run () {
     core.debug(`Latest issue response:\n\n${JSON.stringify(latestIssueResponse)}\n\n`)
 
     const previousIssueNumber = latestIssueResponse.number
-    const previousId = latestIssueResponse.id
+    const previousIssueId = latestIssueResponse.id
     let currentAssignee = null
     if (latestIssueResponse.assignees && latestIssueResponse.assignees.nodes.length > 0) {
       currentAssignee = latestIssueResponse.assignees.nodes[0].login

--- a/dist/index.js
+++ b/dist/index.js
@@ -143,7 +143,7 @@ const getTemplateFromFile = async (templateFilePath) => {
 async function run () {
   try {
     const assignees = core.getInput('assignees');
-    const rotateAssignees = core.getInput('rotate-assignees');
+    const rotateAssignees = core.getInput('rotate-assignees') === 'true';
     const title = core.getInput('title');
     let body = core.getInput('body');
     const labels = core.getInput('labels');
@@ -231,8 +231,6 @@ async function run () {
       // Reset array of assignees to single assignee, next in list
       metadata.assignees = [metadata.assignees[index]]
     }
-
-    core.debug(`Metadata.assignees: ${metadata.assignees}`)
 
     // Create a new issue
     const { data: { number: newIssueNumber } } = await octokit.issues.create({

--- a/dist/index.js
+++ b/dist/index.js
@@ -201,6 +201,9 @@ async function run () {
 
     // Run the query, save the number (ex. 79) and GraphQL id (ex. MDU6SXMzbWU0ODAxNzI0NDA=)
     const latestIssueResponse = (await octokit.graphql(latestIssueQuery)).resource.issues.nodes[0] || {};
+
+    core.debug(`Latest issue response:\n\n${JSON.stringify(latestIssueResponse)}\n\n`)
+
     const previousIssueNumber = latestIssueQuery.number
     const previousId = latestIssueQuery.id
     let currentAssignee = ''

--- a/dist/index.js
+++ b/dist/index.js
@@ -215,11 +215,15 @@ async function run () {
     if (rotateAssignees) {
       let index = metadata.assignees.indexOf();
       const length = metadata.assignees.length();
-      if (length - 1 === index) {
+      // If last assignee in array
+      if (length - 1 <= index) {
         index = 0;
       } else {
         index++;
       }
+
+      // Reset array of assignees to single assignee, next in list
+      metadata.assignees = [`'${metadata.assignees[index]}'`]
     }
 
     // Create a new issue

--- a/dist/index.js
+++ b/dist/index.js
@@ -229,7 +229,7 @@ async function run () {
       }
 
       // Reset array of assignees to single assignee, next in list
-      metadata.assignees = [`'${metadata.assignees[index]}'`]
+      metadata.assignees = [metadata.assignees[index]]
     }
 
     core.debug(`Metadata.assignees: ${metadata.assignees}`)

--- a/dist/index.js
+++ b/dist/index.js
@@ -143,6 +143,7 @@ const getTemplateFromFile = async (templateFilePath) => {
 async function run () {
   try {
     const assignees = core.getInput('assignees');
+    const rotateAssignees = core.getInput('rotate-assignees');
     const title = core.getInput('title');
     let body = core.getInput('body');
     const labels = core.getInput('labels');
@@ -179,7 +180,7 @@ async function run () {
     metadata.assignees = metadata.assignees.split(',').map(s => s.trim()); // 'user1, user2' --> ['user1', 'user2']
     metadata.labels = metadata.labels.split(',').map(s => s.trim()); // 'label1, label2' --> ['label1', 'label2']
 
-    // GraphQL query to get latest matching open issue if it exists
+    // GraphQL query to get latest matching open issue if it exists with assignee
     const latestIssueQuery = `{
       resource(url: "${repo}") {
         ... on Repository {
@@ -187,6 +188,11 @@ async function run () {
             nodes {
               number
               id
+              assignees (first: 1) {
+                nodes {
+                  login
+                }
+              }
             }
           }
         }
@@ -194,15 +200,27 @@ async function run () {
     }`;
 
     // Run the query, save the number (ex. 79) and GraphQL id (ex. MDU6SXMzbWU0ODAxNzI0NDA=)
-    const {
-      number: previousIssueNumber,
-      id: previousIssueId
-    } = (await octokit.graphql(latestIssueQuery)).resource.issues.nodes[0] || {};
+    const latestIssueResponse = (await octokit.graphql(latestIssueQuery)).resource.issues.nodes[0] || {};
+    const previousIssueNumber = latestIssueQuery.number
+    const previousId = latestIssueQuery.id
+    const currentAssignee = latestIssueQuery.assignees.nodes[0].login
 
     core.debug(`Previous issue number: ${previousIssueNumber}`);
+    core.debug(`Previous issue currentAssignee: ${currentAssignee}`);
 
     // Render body with previousIssueNumber
     body = Handlebars.compile(body)({ previousIssueNumber });
+
+    // Rotate assignee to next in list?
+    if (rotateAssignees) {
+      let index = metadata.assignees.indexOf();
+      const length = metadata.assignees.length();
+      if (length - 1 === index) {
+        index = 0;
+      } else {
+        index++;
+      }
+    }
 
     // Create a new issue
     const { data: { number: newIssueNumber } } = await octokit.issues.create({
@@ -285,6 +303,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const os = __importStar(__webpack_require__(2087));
+const utils_1 = __webpack_require__(5278);
 /**
  * Commands
  *
@@ -338,28 +357,14 @@ class Command {
         return cmdStr;
     }
 }
-/**
- * Sanitizes an input into a string so it can be passed into issueCommand safely
- * @param input input to sanitize into a string
- */
-function toCommandValue(input) {
-    if (input === null || input === undefined) {
-        return '';
-    }
-    else if (typeof input === 'string' || input instanceof String) {
-        return input;
-    }
-    return JSON.stringify(input);
-}
-exports.toCommandValue = toCommandValue;
 function escapeData(s) {
-    return toCommandValue(s)
+    return utils_1.toCommandValue(s)
         .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A');
 }
 function escapeProperty(s) {
-    return toCommandValue(s)
+    return utils_1.toCommandValue(s)
         .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A')
@@ -393,6 +398,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const command_1 = __webpack_require__(7351);
+const file_command_1 = __webpack_require__(717);
+const utils_1 = __webpack_require__(5278);
 const os = __importStar(__webpack_require__(2087));
 const path = __importStar(__webpack_require__(5622));
 /**
@@ -419,9 +426,17 @@ var ExitCode;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function exportVariable(name, val) {
-    const convertedVal = command_1.toCommandValue(val);
+    const convertedVal = utils_1.toCommandValue(val);
     process.env[name] = convertedVal;
-    command_1.issueCommand('set-env', { name }, convertedVal);
+    const filePath = process.env['GITHUB_ENV'] || '';
+    if (filePath) {
+        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        file_command_1.issueCommand('ENV', commandValue);
+    }
+    else {
+        command_1.issueCommand('set-env', { name }, convertedVal);
+    }
 }
 exports.exportVariable = exportVariable;
 /**
@@ -437,7 +452,13 @@ exports.setSecret = setSecret;
  * @param inputPath
  */
 function addPath(inputPath) {
-    command_1.issueCommand('add-path', {}, inputPath);
+    const filePath = process.env['GITHUB_PATH'] || '';
+    if (filePath) {
+        file_command_1.issueCommand('PATH', inputPath);
+    }
+    else {
+        command_1.issueCommand('add-path', {}, inputPath);
+    }
     process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
 }
 exports.addPath = addPath;
@@ -596,6 +617,68 @@ function getState(name) {
 }
 exports.getState = getState;
 //# sourceMappingURL=core.js.map
+
+/***/ }),
+
+/***/ 717:
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+"use strict";
+
+// For internal use, subject to change.
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const fs = __importStar(__webpack_require__(5747));
+const os = __importStar(__webpack_require__(2087));
+const utils_1 = __webpack_require__(5278);
+function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
+        encoding: 'utf8'
+    });
+}
+exports.issueCommand = issueCommand;
+//# sourceMappingURL=file-command.js.map
+
+/***/ }),
+
+/***/ 5278:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+/**
+ * Sanitizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+function toCommandValue(input) {
+    if (input === null || input === undefined) {
+        return '';
+    }
+    else if (typeof input === 'string' || input instanceof String) {
+        return input;
+    }
+    return JSON.stringify(input);
+}
+exports.toCommandValue = toCommandValue;
+//# sourceMappingURL=utils.js.map
 
 /***/ }),
 

--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ async function run () {
     metadata.assignees = metadata.assignees.split(',').map(s => s.trim()); // 'user1, user2' --> ['user1', 'user2']
     metadata.labels = metadata.labels.split(',').map(s => s.trim()); // 'label1, label2' --> ['label1', 'label2']
 
-    // GraphQL query to get latest matching open issue if it exists with assignee
+    // GraphQL query to get latest matching open issue, if it exists, along with first assignee
     const latestIssueQuery = `{
       resource(url: "${repo}") {
         ... on Repository {

--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ async function run () {
     const previousIssueNumber = latestIssueQuery.number
     const previousId = latestIssueQuery.id
     let currentAssignee = ''
-    if (latestIssueQuery.assignees.nodes.length() > 0) {
+    if (latestIssueQuery.assignees.nodes && latestIssueQuery.assignees.nodes.length() > 0) {
       currentAssignee = latestIssueQuery.assignees.nodes[0].login
     }
 

--- a/index.js
+++ b/index.js
@@ -209,14 +209,7 @@ async function run () {
 
     // Rotate assignee to next in list?
     if (rotateAssignees) {
-      let index = metadata.assignees.indexOf(currentAssignee);
-      const length = metadata.assignees.length;
-      // If last assignee in array
-      if (length - 1 <= index) {
-        index = 0;
-      } else {
-        index++;
-      }
+  let index = (metadata.assignees.indexOf(currentAssignee) + 1) % metadata.assignees.length;
 
       // Reset array of assignees to single assignee, next in list
       metadata.assignees = [metadata.assignees[index]]

--- a/index.js
+++ b/index.js
@@ -225,6 +225,8 @@ async function run () {
       metadata.assignees = [`'${metadata.assignees[index]}'`]
     }
 
+    core.debug(`Metadata.assignees: ${metadata.assignees}`)
+
     // Create a new issue
     const { data: { number: newIssueNumber } } = await octokit.issues.create({
       ...github.context.repo,

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ async function run () {
     core.debug(`Latest issue response:\n\n${JSON.stringify(latestIssueResponse)}\n\n`)
 
     const previousIssueNumber = latestIssueResponse.number
-    const previousId = latestIssueResponse.id
+    const previousIssueId = latestIssueResponse.id
     let currentAssignee = null
     if (latestIssueResponse.assignees && latestIssueResponse.assignees.nodes.length > 0) {
       currentAssignee = latestIssueResponse.assignees.nodes[0].login

--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ async function run () {
       }
 
       // Reset array of assignees to single assignee, next in list
-      metadata.assignees = [`'${metadata.assignees[index]}'`]
+      metadata.assignees = [metadata.assignees[index]]
     }
 
     core.debug(`Metadata.assignees: ${metadata.assignees}`)

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ const getTemplateFromFile = async (templateFilePath) => {
 async function run () {
   try {
     const assignees = core.getInput('assignees');
-    const rotateAssignees = core.getInput('rotate-assignees');
+    const rotateAssignees = core.getInput('rotate-assignees') === 'true';
     const title = core.getInput('title');
     let body = core.getInput('body');
     const labels = core.getInput('labels');
@@ -224,8 +224,6 @@ async function run () {
       // Reset array of assignees to single assignee, next in list
       metadata.assignees = [metadata.assignees[index]]
     }
-
-    core.debug(`Metadata.assignees: ${metadata.assignees}`)
 
     // Create a new issue
     const { data: { number: newIssueNumber } } = await octokit.issues.create({

--- a/index.js
+++ b/index.js
@@ -196,7 +196,10 @@ async function run () {
     const latestIssueResponse = (await octokit.graphql(latestIssueQuery)).resource.issues.nodes[0] || {};
     const previousIssueNumber = latestIssueQuery.number
     const previousId = latestIssueQuery.id
-    const currentAssignee = latestIssueQuery.assignees.nodes[0].login
+    let currentAssignee = ''
+    if (latestIssueQuery.assignees.nodes.length() > 0) {
+      currentAssignee = latestIssueQuery.assignees.nodes[0].login
+    }
 
     core.debug(`Previous issue number: ${previousIssueNumber}`);
     core.debug(`Previous issue currentAssignee: ${currentAssignee}`);
@@ -205,7 +208,7 @@ async function run () {
     body = Handlebars.compile(body)({ previousIssueNumber });
 
     // Rotate assignee to next in list?
-    if (rotateAssignees) {
+    if (rotateAssignees && currentAssignee !== '') {
       let index = metadata.assignees.indexOf();
       const length = metadata.assignees.length();
       // If last assignee in array

--- a/index.js
+++ b/index.js
@@ -199,8 +199,8 @@ async function run () {
 
     const previousIssueNumber = latestIssueResponse.number
     const previousId = latestIssueResponse.id
-    let currentAssignee = ''
-    if (latestIssueResponse.assignees.nodes && latestIssueResponse.assignees.nodes.length() > 0) {
+    let currentAssignee = null
+    if (latestIssueResponse.assignees && latestIssueResponse.assignees.nodes.length() > 0) {
       currentAssignee = latestIssueResponse.assignees.nodes[0].login
     }
 
@@ -211,8 +211,8 @@ async function run () {
     body = Handlebars.compile(body)({ previousIssueNumber });
 
     // Rotate assignee to next in list?
-    if (rotateAssignees && currentAssignee !== '') {
-      let index = metadata.assignees.indexOf();
+    if (rotateAssignees) {
+      let index = metadata.assignees.indexOf(currentAssignee);
       const length = metadata.assignees.length();
       // If last assignee in array
       if (length - 1 <= index) {

--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ async function run () {
     // Rotate assignee to next in list?
     if (rotateAssignees) {
       let index = metadata.assignees.indexOf(currentAssignee);
-      const length = metadata.assignees.length();
+      const length = metadata.assignees.length;
       // If last assignee in array
       if (length - 1 <= index) {
         index = 0;

--- a/index.js
+++ b/index.js
@@ -195,8 +195,6 @@ async function run () {
     // Run the query, save the number (ex. 79) and GraphQL id (ex. MDU6SXMzbWU0ODAxNzI0NDA=)
     const latestIssueResponse = (await octokit.graphql(latestIssueQuery)).resource.issues.nodes[0] || {};
 
-    core.debug(`Latest issue response:\n\n${JSON.stringify(latestIssueResponse)}\n\n`)
-
     const previousIssueNumber = latestIssueResponse.number
     const previousIssueId = latestIssueResponse.id
     let currentAssignee = null

--- a/index.js
+++ b/index.js
@@ -193,14 +193,13 @@ async function run () {
     }`;
 
     // Run the query, save the number (ex. 79) and GraphQL id (ex. MDU6SXMzbWU0ODAxNzI0NDA=)
-    const latestIssueResponse = (await octokit.graphql(latestIssueQuery)).resource.issues.nodes[0] || {};
+    const {
+        number: previousIssueNumber,
+        id: previousIssueId,
+        assignees:  { nodes: previousAssignees }
+    } = (await octokit.graphql(latestIssueQuery)).resource.issues.nodes[0] || {};
 
-    const previousIssueNumber = latestIssueResponse.number
-    const previousIssueId = latestIssueResponse.id
-    let currentAssignee = null
-    if (latestIssueResponse.assignees && latestIssueResponse.assignees.nodes.length > 0) {
-      currentAssignee = latestIssueResponse.assignees.nodes[0].login
-    }
+    let currentAssignee = previousAssignees.length ? previousAssignees[0].login : undefined;
 
     core.debug(`Previous issue number: ${previousIssueNumber}`);
     core.debug(`Previous issue currentAssignee: ${currentAssignee}`);

--- a/index.js
+++ b/index.js
@@ -194,6 +194,9 @@ async function run () {
 
     // Run the query, save the number (ex. 79) and GraphQL id (ex. MDU6SXMzbWU0ODAxNzI0NDA=)
     const latestIssueResponse = (await octokit.graphql(latestIssueQuery)).resource.issues.nodes[0] || {};
+
+    core.debug(`Latest issue response:\n\n${JSON.stringify(latestIssueResponse)}\n\n`)
+
     const previousIssueNumber = latestIssueQuery.number
     const previousId = latestIssueQuery.id
     let currentAssignee = ''

--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ async function run () {
     const previousIssueNumber = latestIssueResponse.number
     const previousId = latestIssueResponse.id
     let currentAssignee = null
-    if (latestIssueResponse.assignees && latestIssueResponse.assignees.nodes.length() > 0) {
+    if (latestIssueResponse.assignees && latestIssueResponse.assignees.nodes.length > 0) {
       currentAssignee = latestIssueResponse.assignees.nodes[0].login
     }
 

--- a/index.js
+++ b/index.js
@@ -197,11 +197,11 @@ async function run () {
 
     core.debug(`Latest issue response:\n\n${JSON.stringify(latestIssueResponse)}\n\n`)
 
-    const previousIssueNumber = latestIssueQuery.number
-    const previousId = latestIssueQuery.id
+    const previousIssueNumber = latestIssueResponse.number
+    const previousId = latestIssueResponse.id
     let currentAssignee = ''
-    if (latestIssueQuery.assignees.nodes && latestIssueQuery.assignees.nodes.length() > 0) {
-      currentAssignee = latestIssueQuery.assignees.nodes[0].login
+    if (latestIssueResponse.assignees.nodes && latestIssueResponse.assignees.nodes.length() > 0) {
+      currentAssignee = latestIssueResponse.assignees.nodes[0].login
     }
 
     core.debug(`Previous issue number: ${previousIssueNumber}`);

--- a/index.js
+++ b/index.js
@@ -208,11 +208,15 @@ async function run () {
     if (rotateAssignees) {
       let index = metadata.assignees.indexOf();
       const length = metadata.assignees.length();
-      if (length - 1 === index) {
+      // If last assignee in array
+      if (length - 1 <= index) {
         index = 0;
       } else {
         index++;
       }
+
+      // Reset array of assignees to single assignee, next in list
+      metadata.assignees = [`'${metadata.assignees[index]}'`]
     }
 
     // Create a new issue


### PR DESCRIPTION
This PR hopes to allow for another optional input, `rotate-assignees`, which would be a boolean variable that allows you to round-robin the assignee of the issue being created. You still provide a list of assignees, and with this variable set to true, the action will look up the previous assignees, and then assign the next person in line when creating the new issue.

/cc @imjohnbo for eyes. I need to test this still, but I think this code is solid. Would love some initial eyes and any tips on testing this.