### PR TITLE
feat: project-type to choose user, organization, repo boards

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,14 +27,22 @@ inputs:
       Assigns new issue to all assignees, or if "rotateAssignees" is set, to the next single assignee whose turn it is.
     required: false
 
+  project-type:
+    description: |-
+      Project type the "project" number corresponds to, e.g. user, organization, or repository project. 
+      Organization and user projects require a GitHub App installation access token, OAuth token, or Personal Access Token.
+      Read more here: https://docs.github.com/en/github/managing-your-work-on-github/about-project-boards.
+      Defaults to "repository".
+    required: false
+
   project:
     description: |-
-      Repository project number (not ID or name) to add issue to, e.g. 2.
+      Project number (not ID or name) to add issue to, e.g. 2.
     required: false
 
   column:
     description: |-
-      Repository project column name to add issue to, e.g. To Do.
+      Project column name to add issue to, e.g. To Do.
       Required if "project" is set.
     required: false
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -22,6 +22,7 @@ try {
     body: core.getInput('body'),
     labels: core.getInput('labels'),
     assignees: core.getInput('assignees'),
+    projectType: core.getInput('project-type'),
     project: core.getInput('project'),
     column: core.getInput('column'),
     milestone: core.getInput('milestone'),
@@ -43,6 +44,12 @@ try {
 
   if (inputs.assignees) {
     inputs.assignees = listToArray(inputs.assignees);
+  }
+
+  // default type of project board is repository board
+  // https://docs.github.com/en/github/managing-your-work-on-github/about-project-boards
+  if (!inputs.projectType) {
+    inputs.projectType = 'repository';
   }
 
   (0,_issue_bot__WEBPACK_IMPORTED_MODULE_0__/* .run */ .KH)(inputs);
@@ -89,17 +96,22 @@ const checkInputs = (inputs) => {
 
   ok = !!inputs.title;
 
+  if (inputs.projectType) {
+    ok = ok && (inputs.projectType === 'user' ||
+      inputs.projectType === 'organization' ||
+      inputs.projectType === 'repository');
+  }
   if (inputs.pinned) {
-    ok = !!inputs.labels;
+    ok = ok && !!inputs.labels;
   }
   if (inputs.closePrevious) {
-    ok = !!inputs.labels;
+    ok = ok && !!inputs.labels;
   }
   if (inputs.linkedComments) {
-    ok = !!inputs.labels;
+    ok = ok && !!inputs.labels;
   }
   if (inputs.rotateAssignees) {
-    ok = !!(inputs.labels && inputs.assignees);
+    ok = ok && !!(inputs.labels && inputs.assignees);
   }
 
   return ok;
@@ -184,7 +196,7 @@ const pin = async (issueId) => {
         }
       }
     }`;
-    // TODO check if 3 issues are already pinned
+  // TODO check if 3 issues are already pinned
   return octokit.graphql({
     query: mutation,
     headers: {
@@ -263,7 +275,7 @@ const getPreviousIssue = async (labels) => {
     previousIssueNodeId = data.node_id;
     previousAssignees = data.assignees;
   } else {
-    core.warning(`Couldn't find previous issue with labels: ${JSON.stringify(labels)}. Proceeding anyway.`);
+    throw new Error(`Couldn't find previous issue with labels: ${JSON.stringify(labels)}.`);
   }
 
   core.debug(`Previous issue number: ${previousIssueNumber}`);
@@ -277,20 +289,45 @@ const getPreviousIssue = async (labels) => {
   };
 };
 
-const addIssueToProjectColumn = async (issueId, projectNumber, columnName) => {
-  core.info(`Adding issue id ${issueId} to project number ${projectNumber}, column name ${columnName}`);
+const addIssueToProjectColumn = async (options) => {
+  core.info(`Adding issue id ${options.issueId} to project type ${options.projectType}, project number ${options.projectNumber}, column name ${options.columnName}`);
+  const projects = [];
 
-  const { data: projects } = await octokit.projects.listForRepo({
-    ...context.repo
-  });
+  if (options.projectType === 'user') {
+    for await (const response of octokit.paginate.iterator(
+      octokit.projects.listForUser,
+      {
+        username: context.repo.owner
+      }
+    )) {
+      projects.push(...response.data);
+    }
+  } else if (options.projectType === 'organization') {
+    for await (const response of octokit.paginate.iterator(
+      octokit.projects.listForOrg,
+      {
+        org: context.repo.owner
+      }
+    )) {
+      projects.push(...response.data);
+    }
+  } else if (options.projectType === 'repository') {
+    for await (const response of octokit.paginate.iterator(
+      octokit.projects.listForRepo,
+      {
+        ...context.repo
+      }
+    )) {
+      projects.push(...response.data);
+    }
+  }
 
-  core.debug(`Found repository projects: ${JSON.stringify(projects)}`);
+  core.debug(`Found projects: ${JSON.stringify(projects)}`);
 
-  const project = projects.find(project => project.number === Number(projectNumber));
+  const project = projects.find(project => project.number === Number(options.projectNumber));
 
   if (!project) {
-    core.warning(`Project with number ${projectNumber} could not be found in this repository. Proceeding without adding issue to project...`);
-    return;
+    throw new Error(`Project with type ${options.projectType}, number ${options.projectNumber} could not be found.`);
   }
 
   const { data: columns } = await octokit.projects.listColumns({
@@ -299,20 +336,19 @@ const addIssueToProjectColumn = async (issueId, projectNumber, columnName) => {
 
   core.debug(`Found columns for project id ${project.id}: ${JSON.stringify(columns)}`);
 
-  const column = columns.find(column => column.name === columnName);
+  const column = columns.find(column => column.name === options.columnName);
 
-  core.debug(`Found column matching column name ${columnName}: ${JSON.stringify(column)}`);
+  core.debug(`Found column matching column name ${options.columnName}: ${JSON.stringify(column)}`);
 
   if (!column) {
-    core.warning(`Column with name ${columnName} could not be found in repository project with id ${projectNumber}. Proceeding without adding issue to project...`);
-    return;
+    throw new Error(`Column with name ${options.columnName} could not be found in project with type ${options.projectType}, id ${options.projectNumber}.`);
   }
 
-  core.debug(`Column name ${columnName} maps to column id ${column.id}`);
+  core.debug(`Column name ${options.columnName} maps to column id ${column.id}`);
 
   await octokit.projects.createCard({
     column_id: column.id,
-    content_id: issueId,
+    content_id: options.issueId,
     content_type: 'Issue'
   });
 };
@@ -327,7 +363,7 @@ const addIssueToMilestone = async (issueNumber, milestoneNumber) => {
   });
 
   if (!issue) {
-    core.warning(`Couldn't add issue ${issueNumber} to milestone ${milestoneNumber}. Proceeding without adding issue to milestone...`);
+    throw new Error(`Couldn't add issue ${issueNumber} to milestone ${milestoneNumber}.`);
   }
 };
 
@@ -356,7 +392,12 @@ const run = async (inputs) => {
     const { newIssueNumber, newIssueId, newIssueNodeId } = await createNewIssue(inputs);
 
     if (inputs.project && inputs.column) {
-      await addIssueToProjectColumn(newIssueId, inputs.project, inputs.column);
+      await addIssueToProjectColumn({
+        issueId: newIssueId,
+        projectType: inputs.projectType,
+        projectNumber: inputs.project,
+        columnName: inputs.column
+      });
     }
 
     if (inputs.milestone) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ try {
     body: core.getInput('body'),
     labels: core.getInput('labels'),
     assignees: core.getInput('assignees'),
+    projectType: core.getInput('project-type'),
     project: core.getInput('project'),
     column: core.getInput('column'),
     milestone: core.getInput('milestone'),
@@ -33,6 +34,12 @@ try {
 
   if (inputs.assignees) {
     inputs.assignees = listToArray(inputs.assignees);
+  }
+
+  // default type of project board is repository board
+  // https://docs.github.com/en/github/managing-your-work-on-github/about-project-boards
+  if (!inputs.projectType) {
+    inputs.projectType = 'repository';
   }
 
   run(inputs);

--- a/lib/issue-bot.js
+++ b/lib/issue-bot.js
@@ -30,17 +30,22 @@ const checkInputs = (inputs) => {
 
   ok = !!inputs.title;
 
+  if (inputs.projectType) {
+    ok = ok && (inputs.projectType === 'user' ||
+      inputs.projectType === 'organization' ||
+      inputs.projectType === 'repository');
+  }
   if (inputs.pinned) {
-    ok = !!inputs.labels;
+    ok = ok && !!inputs.labels;
   }
   if (inputs.closePrevious) {
-    ok = !!inputs.labels;
+    ok = ok && !!inputs.labels;
   }
   if (inputs.linkedComments) {
-    ok = !!inputs.labels;
+    ok = ok && !!inputs.labels;
   }
   if (inputs.rotateAssignees) {
-    ok = !!(inputs.labels && inputs.assignees);
+    ok = ok && !!(inputs.labels && inputs.assignees);
   }
 
   return ok;
@@ -125,7 +130,7 @@ const pin = async (issueId) => {
         }
       }
     }`;
-    // TODO check if 3 issues are already pinned
+  // TODO check if 3 issues are already pinned
   return octokit.graphql({
     query: mutation,
     headers: {
@@ -204,7 +209,7 @@ const getPreviousIssue = async (labels) => {
     previousIssueNodeId = data.node_id;
     previousAssignees = data.assignees;
   } else {
-    core.warning(`Couldn't find previous issue with labels: ${JSON.stringify(labels)}. Proceeding anyway.`);
+    throw new Error(`Couldn't find previous issue with labels: ${JSON.stringify(labels)}.`);
   }
 
   core.debug(`Previous issue number: ${previousIssueNumber}`);
@@ -218,20 +223,45 @@ const getPreviousIssue = async (labels) => {
   };
 };
 
-const addIssueToProjectColumn = async (issueId, projectNumber, columnName) => {
-  core.info(`Adding issue id ${issueId} to project number ${projectNumber}, column name ${columnName}`);
+const addIssueToProjectColumn = async (options) => {
+  core.info(`Adding issue id ${options.issueId} to project type ${options.projectType}, project number ${options.projectNumber}, column name ${options.columnName}`);
+  const projects = [];
 
-  const { data: projects } = await octokit.projects.listForRepo({
-    ...context.repo
-  });
+  if (options.projectType === 'user') {
+    for await (const response of octokit.paginate.iterator(
+      octokit.projects.listForUser,
+      {
+        username: context.repo.owner
+      }
+    )) {
+      projects.push(...response.data);
+    }
+  } else if (options.projectType === 'organization') {
+    for await (const response of octokit.paginate.iterator(
+      octokit.projects.listForOrg,
+      {
+        org: context.repo.owner
+      }
+    )) {
+      projects.push(...response.data);
+    }
+  } else if (options.projectType === 'repository') {
+    for await (const response of octokit.paginate.iterator(
+      octokit.projects.listForRepo,
+      {
+        ...context.repo
+      }
+    )) {
+      projects.push(...response.data);
+    }
+  }
 
-  core.debug(`Found repository projects: ${JSON.stringify(projects)}`);
+  core.debug(`Found projects: ${JSON.stringify(projects)}`);
 
-  const project = projects.find(project => project.number === Number(projectNumber));
+  const project = projects.find(project => project.number === Number(options.projectNumber));
 
   if (!project) {
-    core.warning(`Project with number ${projectNumber} could not be found in this repository. Proceeding without adding issue to project...`);
-    return;
+    throw new Error(`Project with type ${options.projectType}, number ${options.projectNumber} could not be found.`);
   }
 
   const { data: columns } = await octokit.projects.listColumns({
@@ -240,20 +270,19 @@ const addIssueToProjectColumn = async (issueId, projectNumber, columnName) => {
 
   core.debug(`Found columns for project id ${project.id}: ${JSON.stringify(columns)}`);
 
-  const column = columns.find(column => column.name === columnName);
+  const column = columns.find(column => column.name === options.columnName);
 
-  core.debug(`Found column matching column name ${columnName}: ${JSON.stringify(column)}`);
+  core.debug(`Found column matching column name ${options.columnName}: ${JSON.stringify(column)}`);
 
   if (!column) {
-    core.warning(`Column with name ${columnName} could not be found in repository project with id ${projectNumber}. Proceeding without adding issue to project...`);
-    return;
+    throw new Error(`Column with name ${options.columnName} could not be found in project with type ${options.projectType}, id ${options.projectNumber}.`);
   }
 
-  core.debug(`Column name ${columnName} maps to column id ${column.id}`);
+  core.debug(`Column name ${options.columnName} maps to column id ${column.id}`);
 
   await octokit.projects.createCard({
     column_id: column.id,
-    content_id: issueId,
+    content_id: options.issueId,
     content_type: 'Issue'
   });
 };
@@ -268,7 +297,7 @@ const addIssueToMilestone = async (issueNumber, milestoneNumber) => {
   });
 
   if (!issue) {
-    core.warning(`Couldn't add issue ${issueNumber} to milestone ${milestoneNumber}. Proceeding without adding issue to milestone...`);
+    throw new Error(`Couldn't add issue ${issueNumber} to milestone ${milestoneNumber}.`);
   }
 };
 
@@ -297,7 +326,12 @@ const run = async (inputs) => {
     const { newIssueNumber, newIssueId, newIssueNodeId } = await createNewIssue(inputs);
 
     if (inputs.project && inputs.column) {
-      await addIssueToProjectColumn(newIssueId, inputs.project, inputs.column);
+      await addIssueToProjectColumn({
+        issueId: newIssueId,
+        projectType: inputs.projectType,
+        projectNumber: inputs.project,
+        columnName: inputs.column
+      });
     }
 
     if (inputs.milestone) {

--- a/tests/issue-bot.test.js
+++ b/tests/issue-bot.test.js
@@ -109,6 +109,14 @@ describe('issueBot', () => {
         expect(ok).toBe(false);
     });
 
+    test('checkInputs: fail if projectType doesnt match user, organization, or repository', () => {
+        const ok = issueBot.checkInputs({
+            title: 'Title',
+            projectType: 'nonsense'
+        })
+        expect(ok).toBe(false);
+    });
+
     test('getNextAssignee: defaults to empty assignee', () => {
         const next = issueBot.getNextAssignee([''], '')
         expect(next).toEqual(['']);


### PR DESCRIPTION
Closes https://github.com/imjohnbo/issue-bot/issues/34

Adds `project-type` inputs, which accepts `user`, `organization`, and `repository` (default). If `user` or `organization` is chosen, a `GITHUB_TOKEN` environment variable with sufficient permission is required – `${{ secrets.GITHUB_TOKEN}}` will not work.

Fails if issue cannot be added to `project`, `milestone`, or a previous issue with `labels` cannot be found.