### PR TITLE
Support for ProjectsV2, closes #72

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Issue Bot is a flexible GitHub action that takes care of a few issue related tas
 - Makes issue comments linking new and previous issues if `linked-comments` is true
 - Assigns new issue only to the _next_ assignee in the list if `rotate-assignees` is true. Useful for duty rotation like first responder.
 - Pairs well with [imjohnbo/extract-issue-template-fields](https://github.com/imjohnbo/extract-issue-template-fields) if you'd prefer to open issues based on [issue templates](https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates#issue-templates)
+- Supports Projects V2 (previously known as Projects Beta and Projects Next).
 
 ## v3 Migration
 ⚠️ If you're a `v2` user, please note that these breaking changes were introduced in `v3`: ⚠️
@@ -119,6 +120,29 @@ The issue body is treated as a [Handlebars](https://handlebarsjs.com) template, 
 The linked comments (`linked-comments-new-issue-text`, `linked-comments-previous-issue-text`) support these variables _and_:
 
 - `newIssueNumber`: The new issue number.
+
+
+## Projects V2 support:
+
+Projects V2 were previously known as Projects Beta and Projects Next.
+
+It works both for user owned projects and organization owned projects. Note that there are no repository owned projects V2.
+
+To use it simply put project url:
+```yaml 
+projectV2: orgs/{name}/projects/{number}
+projectV2: users/{name}/projects/{number}
+```
+
+e.g.
+```
+token: ...github_pat_token_with_project_scope
+projectV2: orgs/github/projects/2
+projectV2: users/octokit/projects/31
+```
+
+Please note that Projects V2 are still in beta and they require Github Personal Access Token (PAT) with full 'project' scope. You can set it via the `token:` field.
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -130,15 +130,15 @@ It works both for user owned projects and organization owned projects. Note that
 
 To use it simply put project url:
 ```yaml 
-projectV2: orgs/{name}/projects/{number}
-projectV2: users/{name}/projects/{number}
+project-v2-path: orgs/{name}/projects/{number}
+project-v2-path: users/{name}/projects/{number}
 ```
 
 e.g.
 ```
 token: ...github_pat_token_with_project_scope
-projectV2: orgs/github/projects/2
-projectV2: users/octokit/projects/31
+project-v2-path: orgs/github/projects/2
+project-v2-path: users/octokit/projects/31
 ```
 
 Please note that Projects V2 are still in beta and they require Github Personal Access Token (PAT) with full 'project' scope. You can set it via the `token:` field.

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,11 @@ inputs:
       Project number (not ID or name) to add issue to, e.g. 2.
     required: false
 
+  projectV2:
+    description: |-
+      Project V2/beta/next node ID to add issue, e.g. "PN_1N4bGfgAAc4A72H1"
+    required: false
+
   column:
     description: |-
       Project column name to add issue to, e.g. To Do.

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
       Project number (not ID or name) to add issue to, e.g. 2.
     required: false
 
-  projectV2:
+  project-v2-path:
     description: |-
       Project V2 / beta / next URL. For user projects use "users/{username}/projects/{number}"
       and for orgs use "orgs/{name}/projects/{number}". Projects V2 does not support repository projects.

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,10 @@ inputs:
 
   projectV2:
     description: |-
-      Project V2/beta/next node ID to add issue, e.g. "PN_1N4bGfgAAc4A72H1"
+      Project V2 / beta / next URL. For user projects use "users/{username}/projects/{number}"
+      and for orgs use "orgs/{name}/projects/{number}". Projects V2 does not support repository projects.
+      The "token" field must be set to Github PAT (Personal Access Token) which is a requirement
+      of Projects V2 graphql. The PAT token needs to have the full "project" scope permissions.
     required: false
 
   column:

--- a/dist/index.js
+++ b/dist/index.js
@@ -298,7 +298,7 @@ const addIssueToProjectV2 = async (options) => {
   mutation {
     addProjectV2ItemById(
       input: {
-        clientMutationId: "${Math.random()}"
+        clientMutationId: "${(new Date()).getTime()}${Math.random()}"
         projectId: "${options.projectNodeId}"
         contentId: "${options.issueNodeId}"
       }

--- a/dist/index.js
+++ b/dist/index.js
@@ -294,13 +294,12 @@ const addIssueToProjectColumn = async (options) => {
 
 const addIssueToProjectV2 = async (options) => {
   core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 URL: ${options.url}`);
-  const projectNodeId = await getProjectV2NodeIdFromUrl(options.url)
+  const projectNodeId = await getProjectV2NodeIdFromUrl(options.url);
   core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 with node ID: ${projectNodeId}`);
   const mutation = `
   mutation {
     addProjectV2ItemById(
       input: {
-        clientMutationId: "${(new Date()).getTime()}${Math.random()}"
         projectId: "${projectNodeId}"
         contentId: "${options.issueNodeId}"
       }
@@ -321,19 +320,19 @@ const addIssueToProjectV2 = async (options) => {
 };
 
 const getProjectV2NodeIdFromUrl = async (url) => {
-  const match = /^.*(?<type>orgs|users)\/(?<name>[^\/]+)\/projects\/(?<number>[0-9]+).*$/gm
-    .exec(url.trim())
+  const match = /^.*(?<type>orgs|users)\/(?<name>[^/]+)\/projects\/(?<number>[0-9]+).*$/gm
+    .exec(url.trim());
   if (!match || !match.groups || !match.groups.type || !match.groups.name || !match.groups.number) {
-    throw new Error('Malformed projectV2 url')
+    throw new Error('Malformed projectV2 url');
   }
-  const { type, name, number } = match.groups
-  return type === "orgs" ?
-    await getOrgProjectV2NodeId({ name, number })
-    : await getUserProjectV2NodeId({ name, number })
-}
+  const { type, name, number } = match.groups;
+  return type === 'orgs'
+    ? await getOrgProjectV2NodeId({ name, number })
+    : await getUserProjectV2NodeId({ name, number });
+};
 
 const getUserProjectV2NodeId = async (options) => {
-  const { name, number } = options
+  const { name, number } = options;
   const query = `
   query FindUserProjectNodeID {
       user(login: "${name}") {
@@ -342,18 +341,18 @@ const getUserProjectV2NodeId = async (options) => {
           }
       }
   }
-  `
+  `;
   const data = await octokit.graphql({
     query,
     headers: {
       accept: 'application/vnd.github.elektra-preview+json'
     }
   });
-  return data.user.projectV2.id
-}
+  return data.user.projectV2.id;
+};
 
 const getOrgProjectV2NodeId = async (options) => {
-  const { name, number } = options
+  const { name, number } = options;
   const query = `
   query FindOrgProjectNodeID {
       organization(login: "${name}") {
@@ -362,15 +361,15 @@ const getOrgProjectV2NodeId = async (options) => {
           }
       }
   }
-  `
+  `;
   const data = await octokit.graphql({
     query,
     headers: {
       accept: 'application/vnd.github.elektra-preview+json'
     }
   });
-  return data.organization.projectV2.id
-}
+  return data.organization.projectV2.id;
+};
 
 const addIssueToMilestone = async (issueNumber, milestoneNumber) => {
   core.info(`Adding issue number ${issueNumber} to milestone number ${milestoneNumber}`);
@@ -425,7 +424,7 @@ const run = async (inputs) => {
     if (inputs.projectV2) {
       await addIssueToProjectV2({
         issueNodeId: newIssueNodeId,
-        url: inputs.projectV2,
+        url: inputs.projectV2
       });
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -369,7 +369,7 @@ const getOrgProjectV2NodeId = async (options) => {
       accept: 'application/vnd.github.elektra-preview+json'
     }
   });
-  return data.user.projectV2.id
+  return data.organization.projectV2.id
 }
 
 const addIssueToMilestone = async (issueNumber, milestoneNumber) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -292,6 +292,28 @@ const addIssueToProjectColumn = async (options) => {
   });
 };
 
+const addIssueToProjectV2 = async (options) => {
+  core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 with node ID: ${options.projectNodeId}`);
+  const mutation = `mutation {
+    addProjectNextItem(
+      input: {
+        projectId: "${options.projectNodeId}"
+        contentId: "${options.issueNodeId}"
+    ) {
+      projectNextItem {
+        id
+      }
+    }
+  }`;
+
+  return octokit.graphql({
+    query: mutation,
+    headers: {
+      accept: 'application/vnd.github.elektra-preview+json'
+    }
+  });
+};
+
 const addIssueToMilestone = async (issueNumber, milestoneNumber) => {
   core.info(`Adding issue number ${issueNumber} to milestone number ${milestoneNumber}`);
 
@@ -339,6 +361,13 @@ const run = async (inputs) => {
         projectType: inputs.projectType,
         projectNumber: inputs.project,
         columnName: inputs.column
+      });
+    }
+
+    if (inputs.projectV2) {
+      await addIssueToProjectV2({
+        issueNodeId: newIssueNodeId,
+        projectNodeId: inputs.projectV2,
       });
     }
 
@@ -401,6 +430,7 @@ __webpack_unused_export__ = closeIssue;
 __webpack_unused_export__ = makeLinkedComments;
 __webpack_unused_export__ = getPreviousIssue;
 __webpack_unused_export__ = addIssueToProjectColumn;
+__webpack_unused_export__ = addIssueToProjectV2;
 __webpack_unused_export__ = addIssueToMilestone;
 exports.KH = run;
 
@@ -17506,8 +17536,8 @@ try {
     labels: core.getInput('labels'),
     assignees: core.getInput('assignees'),
     projectType: core.getInput('project-type'),
-    projectV2: core.getInput('projectV2'),
     project: core.getInput('project'),
+    projectV2: core.getInput('projectV2'),
     column: core.getInput('column'),
     milestone: core.getInput('milestone'),
     pinned: core.getInput('pinned') === 'true',

--- a/dist/index.js
+++ b/dist/index.js
@@ -293,13 +293,15 @@ const addIssueToProjectColumn = async (options) => {
 };
 
 const addIssueToProjectV2 = async (options) => {
-  core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 with node ID: ${options.projectNodeId}`);
+  core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 URL: ${options.url}`);
+  const projectNodeId = await getProjectV2NodeIdFromUrl(options.url)
+  core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 with node ID: ${projectNodeId}`);
   const mutation = `
   mutation {
     addProjectV2ItemById(
       input: {
         clientMutationId: "${(new Date()).getTime()}${Math.random()}"
-        projectId: "${options.projectNodeId}"
+        projectId: "${projectNodeId}"
         contentId: "${options.issueNodeId}"
       }
     ) {
@@ -317,6 +319,58 @@ const addIssueToProjectV2 = async (options) => {
     }
   });
 };
+
+const getProjectV2NodeIdFromUrl = async (url) => {
+  const match = /^.*(?<type>orgs|users)\/(?<name>[^\/]+)\/projects\/(?<number>[0-9]+).*$/gm
+    .exec(url.trim())
+  if (!match || !match.groups || !match.groups.type || !match.groups.name || !match.groups.number) {
+    throw new Error('Malformed projectV2 url')
+  }
+  const { type, name, number } = match.groups
+  return type === "orgs" ?
+    await getOrgProjectV2NodeId({ name, number })
+    : await getUserProjectV2NodeId({ name, number })
+}
+
+const getUserProjectV2NodeId = async (options) => {
+  const { name, number } = options
+  const query = `
+  query FindUserProjectNodeID {
+      user(login: "${name}") {
+          projectV2(number: ${number}) {
+              id
+          }
+      }
+  }
+  `
+  const data = await octokit.graphql({
+    query,
+    headers: {
+      accept: 'application/vnd.github.elektra-preview+json'
+    }
+  });
+  return data.user.projectV2.id
+}
+
+const getOrgProjectV2NodeId = async (options) => {
+  const { name, number } = options
+  const query = `
+  query FindOrgProjectNodeID {
+      organization(login: "${name}") {
+          projectV2(number: ${number}) {
+              id
+          }
+      }
+  }
+  `
+  const data = await octokit.graphql({
+    query,
+    headers: {
+      accept: 'application/vnd.github.elektra-preview+json'
+    }
+  });
+  return data.user.projectV2.id
+}
 
 const addIssueToMilestone = async (issueNumber, milestoneNumber) => {
   core.info(`Adding issue number ${issueNumber} to milestone number ${milestoneNumber}`);
@@ -371,7 +425,7 @@ const run = async (inputs) => {
     if (inputs.projectV2) {
       await addIssueToProjectV2({
         issueNodeId: newIssueNodeId,
-        projectNodeId: inputs.projectV2,
+        url: inputs.projectV2,
       });
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -294,17 +294,21 @@ const addIssueToProjectColumn = async (options) => {
 
 const addIssueToProjectV2 = async (options) => {
   core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 with node ID: ${options.projectNodeId}`);
-  const mutation = `mutation {
-    addProjectNextItem(
+  const mutation = `
+  mutation {
+    addProjectV2ItemById(
       input: {
+        clientMutationId: "${Math.random()}"
         projectId: "${options.projectNodeId}"
         contentId: "${options.issueNodeId}"
+      }
     ) {
-      projectNextItem {
+      item {
         id
       }
     }
-  }`;
+  }
+  `;
 
   return octokit.graphql({
     query: mutation,

--- a/dist/index.js
+++ b/dist/index.js
@@ -17594,7 +17594,7 @@ try {
     assignees: core.getInput('assignees'),
     projectType: core.getInput('project-type'),
     project: core.getInput('project'),
-    projectV2: core.getInput('project-v2-path'),
+    projectV2: core.getInput('projectV2'),
     column: core.getInput('column'),
     milestone: core.getInput('milestone'),
     pinned: core.getInput('pinned') === 'true',

--- a/dist/index.js
+++ b/dist/index.js
@@ -17594,7 +17594,7 @@ try {
     assignees: core.getInput('assignees'),
     projectType: core.getInput('project-type'),
     project: core.getInput('project'),
-    projectV2: core.getInput('projectV2'),
+    projectV2: core.getInput('project-v2-path'),
     column: core.getInput('column'),
     milestone: core.getInput('milestone'),
     pinned: core.getInput('pinned') === 'true',

--- a/dist/index.js
+++ b/dist/index.js
@@ -17506,6 +17506,7 @@ try {
     labels: core.getInput('labels'),
     assignees: core.getInput('assignees'),
     projectType: core.getInput('project-type'),
+    projectV2: core.getInput('projectV2'),
     project: core.getInput('project'),
     column: core.getInput('column'),
     milestone: core.getInput('milestone'),

--- a/docs/example-workflows/project-v2.yml
+++ b/docs/example-workflows/project-v2.yml
@@ -1,0 +1,37 @@
+#
+# Daily standup, powered by imjohnbo/issue-bot
+#
+name: Daily Standup Projects V2
+on:
+  schedule:
+  # Every day at noon
+  - cron: 0 12 * * * 
+
+jobs:
+  daily_standup:
+    name: Daily Standup Projects V2
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Today's date
+      run: echo "TODAY=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+
+    # Generates and pins new standup issue, closes previous, writes linking comments, and assigns to all assignees in list
+    - name: New standup issue
+      uses: imjohnbo/issue-bot@v3
+      with:
+        assignees: "octocat, monalisa"
+        labels: "standup"
+        title: Standup
+        body: |-
+          :wave: Hi, {{#each assignees}}@{{this}}{{#unless @last}}, {{/unless}}{{/each}}!
+
+          ## Standup for ${{ env.TODAY }}
+
+          1. What did you work on yesterday?
+          2. What are you working on today?
+          3. What issues are blocking you?
+        pinned: true
+        close-previous: true
+        linked-comments: true
+        project-v2-path: users/jblew/projects/2

--- a/docs/example-workflows/project-v2.yml
+++ b/docs/example-workflows/project-v2.yml
@@ -35,3 +35,4 @@ jobs:
         close-previous: true
         linked-comments: true
         project-v2-path: users/jblew/projects/2
+        token: ${{ secrets.PAT }} # for example, a personal access token with `project` scope

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ try {
     assignees: core.getInput('assignees'),
     projectType: core.getInput('project-type'),
     project: core.getInput('project'),
+    projectV2: core.getInput('projectV2'),
     column: core.getInput('column'),
     milestone: core.getInput('milestone'),
     pinned: core.getInput('pinned') === 'true',

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ try {
     assignees: core.getInput('assignees'),
     projectType: core.getInput('project-type'),
     project: core.getInput('project'),
-    projectV2: core.getInput('projectV2'),
+    projectV2: core.getInput('project-v2-path'),
     column: core.getInput('column'),
     milestone: core.getInput('milestone'),
     pinned: core.getInput('pinned') === 'true',

--- a/lib/issue-bot.js
+++ b/lib/issue-bot.js
@@ -285,6 +285,28 @@ const addIssueToProjectColumn = async (options) => {
   });
 };
 
+const addIssueToProjectV2 = async (options) => {
+  core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 with node ID: ${options.projectNodeId}`);
+  const mutation = `mutation {
+    addProjectNextItem(
+      input: {
+        projectId: "${options.projectNodeId}"
+        contentId: "${options.issueNodeId}"
+    ) {
+      projectNextItem {
+        id
+      }
+    }
+  }`;
+
+  return octokit.graphql({
+    query: mutation,
+    headers: {
+      accept: 'application/vnd.github.elektra-preview+json'
+    }
+  });
+};
+
 const addIssueToMilestone = async (issueNumber, milestoneNumber) => {
   core.info(`Adding issue number ${issueNumber} to milestone number ${milestoneNumber}`);
 
@@ -332,6 +354,13 @@ const run = async (inputs) => {
         projectType: inputs.projectType,
         projectNumber: inputs.project,
         columnName: inputs.column
+      });
+    }
+
+    if (inputs.projectV2) {
+      await addIssueToProjectV2({
+        issueNodeId: newIssueNodeId,
+        projectNodeId: inputs.projectV2,
       });
     }
 
@@ -394,5 +423,6 @@ exports.closeIssue = closeIssue;
 exports.makeLinkedComments = makeLinkedComments;
 exports.getPreviousIssue = getPreviousIssue;
 exports.addIssueToProjectColumn = addIssueToProjectColumn;
+exports.addIssueToProjectV2 = addIssueToProjectV2;
 exports.addIssueToMilestone = addIssueToMilestone;
 exports.run = run;

--- a/lib/issue-bot.js
+++ b/lib/issue-bot.js
@@ -287,17 +287,21 @@ const addIssueToProjectColumn = async (options) => {
 
 const addIssueToProjectV2 = async (options) => {
   core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 with node ID: ${options.projectNodeId}`);
-  const mutation = `mutation {
-    addProjectNextItem(
+  const mutation = `
+  mutation {
+    addProjectV2ItemById(
       input: {
+        clientMutationId: "${Math.random()}"
         projectId: "${options.projectNodeId}"
         contentId: "${options.issueNodeId}"
+      }
     ) {
-      projectNextItem {
+      item {
         id
       }
     }
-  }`;
+  }
+  `;
 
   return octokit.graphql({
     query: mutation,

--- a/lib/issue-bot.js
+++ b/lib/issue-bot.js
@@ -287,7 +287,7 @@ const addIssueToProjectColumn = async (options) => {
 
 const addIssueToProjectV2 = async (options) => {
   core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 URL: ${options.url}`);
-  const projectNodeId = await getProjectV2NodeIdFromUrl(options.url)
+  const projectNodeId = await getProjectV2NodeIdFromUrl(options.url);
   core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 with node ID: ${projectNodeId}`);
   const mutation = `
   mutation {
@@ -314,19 +314,19 @@ const addIssueToProjectV2 = async (options) => {
 };
 
 const getProjectV2NodeIdFromUrl = async (url) => {
-  const match = /^.*(?<type>orgs|users)\/(?<name>[^\/]+)\/projects\/(?<number>[0-9]+).*$/gm
-    .exec(url.trim())
+  const match = /^.*(?<type>orgs|users)\/(?<name>[^/]+)\/projects\/(?<number>[0-9]+).*$/gm
+    .exec(url.trim());
   if (!match || !match.groups || !match.groups.type || !match.groups.name || !match.groups.number) {
-    throw new Error('Malformed projectV2 url')
+    throw new Error('Malformed projectV2 url');
   }
-  const { type, name, number } = match.groups
-  return type === "orgs" ?
-    await getOrgProjectV2NodeId({ name, number })
-    : await getUserProjectV2NodeId({ name, number })
-}
+  const { type, name, number } = match.groups;
+  return type === 'orgs'
+    ? await getOrgProjectV2NodeId({ name, number })
+    : await getUserProjectV2NodeId({ name, number });
+};
 
 const getUserProjectV2NodeId = async (options) => {
-  const { name, number } = options
+  const { name, number } = options;
   const query = `
   query FindUserProjectNodeID {
       user(login: "${name}") {
@@ -335,18 +335,18 @@ const getUserProjectV2NodeId = async (options) => {
           }
       }
   }
-  `
+  `;
   const data = await octokit.graphql({
     query,
     headers: {
       accept: 'application/vnd.github.elektra-preview+json'
     }
   });
-  return data.user.projectV2.id
-}
+  return data.user.projectV2.id;
+};
 
 const getOrgProjectV2NodeId = async (options) => {
-  const { name, number } = options
+  const { name, number } = options;
   const query = `
   query FindOrgProjectNodeID {
       organization(login: "${name}") {
@@ -355,15 +355,15 @@ const getOrgProjectV2NodeId = async (options) => {
           }
       }
   }
-  `
+  `;
   const data = await octokit.graphql({
     query,
     headers: {
       accept: 'application/vnd.github.elektra-preview+json'
     }
   });
-  return data.organization.projectV2.id
-}
+  return data.organization.projectV2.id;
+};
 
 const addIssueToMilestone = async (issueNumber, milestoneNumber) => {
   core.info(`Adding issue number ${issueNumber} to milestone number ${milestoneNumber}`);
@@ -418,7 +418,7 @@ const run = async (inputs) => {
     if (inputs.projectV2) {
       await addIssueToProjectV2({
         issueNodeId: newIssueNodeId,
-        url: inputs.projectV2,
+        url: inputs.projectV2
       });
     }
 

--- a/lib/issue-bot.js
+++ b/lib/issue-bot.js
@@ -291,7 +291,7 @@ const addIssueToProjectV2 = async (options) => {
   mutation {
     addProjectV2ItemById(
       input: {
-        clientMutationId: "${Math.random()}"
+        clientMutationId: "${(new Date()).getTime()}${Math.random()}"
         projectId: "${options.projectNodeId}"
         contentId: "${options.issueNodeId}"
       }

--- a/lib/issue-bot.js
+++ b/lib/issue-bot.js
@@ -286,13 +286,15 @@ const addIssueToProjectColumn = async (options) => {
 };
 
 const addIssueToProjectV2 = async (options) => {
-  core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 with node ID: ${options.projectNodeId}`);
+  core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 URL: ${options.url}`);
+  const projectNodeId = await getProjectV2NodeIdFromUrl(options.url)
+  core.info(`Adding issue with node ID ${options.issueNodeId} to project V2 with node ID: ${projectNodeId}`);
   const mutation = `
   mutation {
     addProjectV2ItemById(
       input: {
         clientMutationId: "${(new Date()).getTime()}${Math.random()}"
-        projectId: "${options.projectNodeId}"
+        projectId: "${projectNodeId}"
         contentId: "${options.issueNodeId}"
       }
     ) {
@@ -310,6 +312,58 @@ const addIssueToProjectV2 = async (options) => {
     }
   });
 };
+
+const getProjectV2NodeIdFromUrl = async (url) => {
+  const match = /^.*(?<type>orgs|users)\/(?<name>[^\/]+)\/projects\/(?<number>[0-9]+).*$/gm
+    .exec(url.trim())
+  if (!match || !match.groups || !match.groups.type || !match.groups.name || !match.groups.number) {
+    throw new Error('Malformed projectV2 url')
+  }
+  const { type, name, number } = match.groups
+  return type === "orgs" ?
+    await getOrgProjectV2NodeId({ name, number })
+    : await getUserProjectV2NodeId({ name, number })
+}
+
+const getUserProjectV2NodeId = async (options) => {
+  const { name, number } = options
+  const query = `
+  query FindUserProjectNodeID {
+      user(login: "${name}") {
+          projectV2(number: ${number}) {
+              id
+          }
+      }
+  }
+  `
+  const data = await octokit.graphql({
+    query,
+    headers: {
+      accept: 'application/vnd.github.elektra-preview+json'
+    }
+  });
+  return data.user.projectV2.id
+}
+
+const getOrgProjectV2NodeId = async (options) => {
+  const { name, number } = options
+  const query = `
+  query FindOrgProjectNodeID {
+      organization(login: "${name}") {
+          projectV2(number: ${number}) {
+              id
+          }
+      }
+  }
+  `
+  const data = await octokit.graphql({
+    query,
+    headers: {
+      accept: 'application/vnd.github.elektra-preview+json'
+    }
+  });
+  return data.user.projectV2.id
+}
 
 const addIssueToMilestone = async (issueNumber, milestoneNumber) => {
   core.info(`Adding issue number ${issueNumber} to milestone number ${milestoneNumber}`);
@@ -364,7 +418,7 @@ const run = async (inputs) => {
     if (inputs.projectV2) {
       await addIssueToProjectV2({
         issueNodeId: newIssueNodeId,
-        projectNodeId: inputs.projectV2,
+        url: inputs.projectV2,
       });
     }
 

--- a/lib/issue-bot.js
+++ b/lib/issue-bot.js
@@ -362,7 +362,7 @@ const getOrgProjectV2NodeId = async (options) => {
       accept: 'application/vnd.github.elektra-preview+json'
     }
   });
-  return data.user.projectV2.id
+  return data.organization.projectV2.id
 }
 
 const addIssueToMilestone = async (issueNumber, milestoneNumber) => {

--- a/lib/issue-bot.js
+++ b/lib/issue-bot.js
@@ -293,7 +293,6 @@ const addIssueToProjectV2 = async (options) => {
   mutation {
     addProjectV2ItemById(
       input: {
-        clientMutationId: "${(new Date()).getTime()}${Math.random()}"
         projectId: "${projectNodeId}"
         contentId: "${options.issueNodeId}"
       }


### PR DESCRIPTION
Hi! I've added support for Github Projects V2 (previously known as Projects Beta and Projects Next).
It works both for user owned projects and organization owned projects. Note that there are no repository owned projects V2.

To use it simply put project url:
```yaml 
projectV2: orgs/{name}/projects/{number}
projectV2: users/{name}/projects/{number}
```

e.g.
```
projectV2: orgs/github/projects/2
projectV2: users/octokit/projects/31
```

Please note that Projects V2 are still in beta and they require Github Personal Access Token (PAT) with full 'project' scope. You can set it via the `token:` field.

Closes #72 
