### PR TITLE
Ability to skip when previous issue exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Issue Bot is a flexible GitHub action that takes care of a few issue related tas
 - Opens new issue with `title`, `body`, `labels`, and `assignees`
 - Uses [Mustache templating syntax](https://github.com/janl/mustache.js) in `body`, along with a couple of handy template variables: `assignees` and `previousIssueNumber`
 - Closes most recent previous issue with all `labels` if `close-previous` is true
+- When `skip-on-previous` is true the action skips creating new issue if previous issue with all `labels` exists. You can configure how far into past to look for previous issue using `previous-lookup-since: yyyy-mm-ddThh:mm:ss`.
 - Adds new issue to `project` (user, organization, or repository project based on value of `project-type`), `column`, and `milestone`
 - Pins new issue and unpins previous issue if `pinned` is true
 - Makes issue comments linking new and previous issues if `linked-comments` is true

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,20 @@ inputs:
       Requires "labels".
     default: 'false'
     required: false
+
+  skip-on-previous:
+    description: :-
+      Skips creating issue if previous issue exists.
+    default: 'false'
+    required: false
+
+  previous-lookup-since:
+    description: |-
+      Describes how far into the past should the search for previous issue continue. 
+      Useful for creating scheduled issues with rare occurance times. Formatted as ISO time e.g.:
+      "2022-08-19T00:00:00"
+    default: ''
+    required: false
     
   linked-comments:
     description: |-

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,8 @@ try {
     milestone: core.getInput('milestone'),
     pinned: core.getInput('pinned') === 'true',
     closePrevious: core.getInput('close-previous') === 'true',
+    skipOnPrevious: core.getInput('skip-on-previous') === 'true',
+    previousLookupSince: core.getInput('previous-lookup-since') || undefined,
     rotateAssignees: core.getInput('rotate-assignees') === 'true',
     linkedComments: core.getInput('linked-comments') === 'true',
     linkedCommentsNewIssueText: core.getInput('linked-comments-new-issue-text'),

--- a/lib/issue-bot.js
+++ b/lib/issue-bot.js
@@ -39,6 +39,9 @@ const checkInputs = (inputs) => {
   if (inputs.closePrevious) {
     ok = ok && !!inputs.labels;
   }
+  if (inputs.skipOnPrevious) {
+    ok = ok && !!inputs.labels;
+  }
   if (inputs.linkedComments) {
     ok = ok && !!inputs.labels;
   }
@@ -192,7 +195,8 @@ const makeLinkedComments = async (previousIssueNumber, previousIssueText, newIss
 
 // Return previous issue matching both labels
 // @input labels: ['label1', 'label2']
-const getPreviousIssue = async (labels) => {
+const getPreviousIssue = async (opts) => {
+  const { labels, since } = opts
   core.info(`Finding previous issue with labels: ${JSON.stringify(labels)}...`);
 
   let previousIssueNumber; let previousIssueNodeId; let previousAssignees = '';
@@ -200,7 +204,8 @@ const getPreviousIssue = async (labels) => {
   const data = (await octokit.rest.issues.listForRepo({
     ...context.repo,
     labels,
-    state: 'all'
+    state: 'all',
+    since,
   })).data[0];
 
   if (data) {
@@ -313,8 +318,16 @@ const run = async (inputs) => {
 
     let previousAssignee; let previousIssueNumber = -1; let previousIssueNodeId; let previousAssignees;
 
-    if (needPreviousIssue(inputs.pinned, inputs.closePrevious, inputs.rotateAssignees, inputs.linkedComments)) {
-      ({ previousIssueNumber, previousIssueNodeId, previousAssignees } = await getPreviousIssue(inputs.labels));
+    if (needPreviousIssue(inputs.pinned, inputs.closePrevious, inputs.skipOnPrevious, inputs.rotateAssignees, inputs.linkedComments)) {
+      ({ previousIssueNumber, previousIssueNodeId, previousAssignees } = await getPreviousIssue(
+        { labels: inputs.labels, since: inputs.previousLookupSince }
+      ));
+    }
+
+    if (issueExists(previousIssueNumber) && inputs.skipOnPrevious) {
+      core.info(`Previous issue exists (number ${previousIssueNumber}). Skipping.`);
+      core.setOutput('previous-issue-number', String(previousIssueNumber));
+      return
     }
 
     // Rotate assignee to next in list


### PR DESCRIPTION
Hi! I needed a feature that allows skipping issue creation when a previous one exists.

Use case:
1. Suppose we want to create an issue once a month. Suppose it is a very important issue. Consider that Github Actions Schedule is not a guaranteed to run. Instead we can trigger adding the issue more often but then look up if it already exists.

Example
```yaml
on:
  schedule:
    - cron: "30 5 * * *" # Every day at 5:30

jobs:
  create-issue:
    runs-on: ubuntu-latest
    steps:
- uses: actions/github-script@v6
  id: since
  with:
    script: |
      const isoYYYYMM = new Date().toISOString().slice(0, 7)
      return { since: `${isoYYYYMM}-10T00:00:00` }
- uses: imjohnbo/issue-bot
  with:
    token: "${{ secrets.GH_PAT }}"
    assignees: "jblew"
    labels: "pay-social-tax"
    title: Pay the social-tax
    skip-on-previous: true
    previous-lookup-since: ${{ steps.since.outputs.results.since }}
    body: |-
      Pay the Social tax... Here is the number...
```
This way we can easily make sure the issue appears in a repository each 10th day of month.

What do you think of that? I just needed it myself but thought it might be useful so I created a PR 😄 :octocat:  