### PR TITLE
Output Project V2 Issue Item ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ linked-comments-previous-issue-text:::optional-->action(Issue Bot Action):::acti
 rotate-assignees:::optional-->action(Issue Bot Action):::action
 action(Issue Bot Action)-->issue-number:::output
 action(Issue Bot Action)-->previous-issue-number:::output
+action(Issue Bot Action)-->project-v2-issue-item-id:::output
 classDef required fill:#6ba06a,stroke:#333,stroke-width:3px
 classDef optional fill:#d9b430,stroke:#333,stroke-width:3px
 classDef action fill:blue,stroke:#333,stroke-width:3px,color:#ffffff
@@ -107,6 +108,7 @@ click linked-comments-previous-issue-text "https://github.com/imjohnbo/issue-bot
 click rotate-assignees "https://github.com/imjohnbo/issue-bot/blob/main/action.yml#L96"
 click issue-number "https://github.com/imjohnbo/issue-bot/blob/main/action.yml#L104"
 click previous-issue-number "https://github.com/imjohnbo/issue-bot/blob/main/action.yml#L107"
+click project-v2-issue-item-id "https://github.com/imjohnbo/issue-bot/blob/main/action.yml#L117"
 ```
 <!-- END MERMAID -->
 

--- a/action.yml
+++ b/action.yml
@@ -114,6 +114,8 @@ outputs:
   previous-issue-number:
     description: 'The issue number of the previous issue, if available'
 
+  project-v2-issue-item-id:
+    description: 'The issue item id of the Projects v2, if available'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -398,6 +398,7 @@ const run = async (inputs) => {
     core.info(`Running with inputs: ${JSON.stringify(inputs)}`);
 
     let previousAssignee; let previousIssueNumber = -1; let previousIssueNodeId; let previousAssignees;
+    let projectV2IssueItemId;
 
     if (needPreviousIssue(inputs.pinned, inputs.closePrevious, inputs.rotateAssignees, inputs.linkedComments)) {
       ({ previousIssueNumber, previousIssueNodeId, previousAssignees } = await getPreviousIssue(inputs.labels));
@@ -422,10 +423,11 @@ const run = async (inputs) => {
     }
 
     if (inputs.projectV2) {
-      await addIssueToProjectV2({
+      const response = await addIssueToProjectV2({
         issueNodeId: newIssueNodeId,
         url: inputs.projectV2
       });
+      projectV2IssueItemId = response.addProjectV2ItemById.item.id;
     }
 
     if (inputs.milestone) {
@@ -469,6 +471,11 @@ const run = async (inputs) => {
     if (previousIssueNumber) {
       core.info(`Previous issue number: ${previousIssueNumber}`);
       core.setOutput('previous-issue-number', String(previousIssueNumber));
+    }
+
+    if (projectV2IssueItemId) {
+      core.info(`Project V2 Issue Item Id: ${projectV2IssueItemId}`);
+      core.setOutput('project-v2-issue-item-id', projectV2IssueItemId);
     }
   } catch (error) {
     core.setFailed(`Error encountered: ${error}.`);

--- a/lib/issue-bot.js
+++ b/lib/issue-bot.js
@@ -391,6 +391,7 @@ const run = async (inputs) => {
     core.info(`Running with inputs: ${JSON.stringify(inputs)}`);
 
     let previousAssignee; let previousIssueNumber = -1; let previousIssueNodeId; let previousAssignees;
+    let projectV2IssueItemId;
 
     if (needPreviousIssue(inputs.pinned, inputs.closePrevious, inputs.rotateAssignees, inputs.linkedComments)) {
       ({ previousIssueNumber, previousIssueNodeId, previousAssignees } = await getPreviousIssue(inputs.labels));
@@ -415,10 +416,11 @@ const run = async (inputs) => {
     }
 
     if (inputs.projectV2) {
-      await addIssueToProjectV2({
+      const response = await addIssueToProjectV2({
         issueNodeId: newIssueNodeId,
         url: inputs.projectV2
       });
+      projectV2IssueItemId = response.addProjectV2ItemById.item.id;
     }
 
     if (inputs.milestone) {
@@ -462,6 +464,11 @@ const run = async (inputs) => {
     if (previousIssueNumber) {
       core.info(`Previous issue number: ${previousIssueNumber}`);
       core.setOutput('previous-issue-number', String(previousIssueNumber));
+    }
+
+    if (projectV2IssueItemId) {
+      core.info(`Project V2 Issue Item Id: ${projectV2IssueItemId}`);
+      core.setOutput('project-v2-issue-item-id', projectV2IssueItemId);
     }
   } catch (error) {
     core.setFailed(`Error encountered: ${error}.`);


### PR DESCRIPTION
Hi 👋.  How do you think about adding an output parameter for "Project V2 Item ID", which will be returned by `addProjectV2ItemById` function call?

## Background
- I was trying to update some fields of the project item, after creating an issue using `issue-bot` with `project-v2-path` option.
- One approach would be to use custom actions like [titoportas/update-project-fields](https://github.com/titoportas/update-project-fields), but it requires Item ID for the Project V2 board as an input, which will be used for [updateProjectV2ItemFieldValue](https://docs.github.com/en/graphql/reference/mutations#updateprojectv2itemfieldvalue) call.
  - https://github.com/titoportas/update-project-fields/blob/main/src/update-project-fields.ts#L212
- [actions/add-to-project](https://github.com/actions/add-to-project) has `itemId` output, and I am wondering if the `issue-bot` can have similar output.
  - https://github.com/actions/add-to-project/blob/main/src/add-to-project.ts#L138

## Change
- Add `project-v2-issue-item-id` output parameter.
  - The value is retrieved from the `addProjectV2ItemById` call response (`addProjectV2ItemById.item.id`)

## Example
### Workflow

```yaml
name: Open Issues (Sample)
on:
  workflow_dispatch:
env:
  PROJECT_NUMBER: 1
  ORGANIZATION: xxx
  REPOSITORY: yyy
jobs:
  create:
    name: Create issues
    runs-on: ubuntu-latest
    steps:
    - name: Get token
      id: get_workflow_token
      uses: peter-murray/workflow-application-token-action@v1
      with:
        application_id: ${{ secrets.APPLICATION_ID }}
        application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
    - name: Create new issue
      id: create-issue
      uses: parroty/issue-bot@with-item-id
      with:
        title: "Test Title"
        body: "Test Body"
        project-v2-path: "orgs/${{ env.ORGANIZATION }}/projects/${{ env.PROJECT_NUMBER }}"
        token: ${{ steps.get_workflow_token.outputs.token }}
    - uses: titoportas/update-project-fields@v0.1.0
      with:
        project-url: "https://github.com/orgs/${{ env.ORGANIZATION }}/projects/${{ env.PROJECT_NUMBER }}"
        github-token: ${{ steps.get_workflow_token.outputs.token }}
        item-id: ${{ steps.create-issue.outputs.project-v2-issue-item-id }}
        field-keys: "Status,Component,Size"
        field-values: "Todo,Frontend,5"
```

### Action Logs (Exerpt)

```
Run parroty/issue-bot@with-item-id
...

Adding issue with node ID I_kwDXIIG0F85Ta8sL to project V2 URL: orgs/xxx/projects/1
Adding issue with node ID I_kwDXIIG0F85Ta8sL to project V2 with node ID: PVT_kwXOBg-OtM4AGxgx
New issue number: 35

Previous issue number: -1

Project V2 Issue Item Id: PVTI_lAXOBg-OtM4AGxgxzgC0P1Q
```

